### PR TITLE
Evol : fermeture PSN

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/dto/PsnStatutDTO.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/dto/PsnStatutDTO.java
@@ -20,8 +20,15 @@ public class PsnStatutDTO {
 
 	@JsonProperty("TIME-STBREVIN-CERTE")
 	private String time_st_brevin;
+	
+	private String closed_from;
+	
+	private String closed_to;
+	
+	private String error;
 
-	public String getCode_current_mode() {
+
+  public String getCode_current_mode() {
 		return code_current_mode;
 	}
 
@@ -60,5 +67,29 @@ public class PsnStatutDTO {
 	public void setTime_st_brevin(String time_st_brevin) {
 		this.time_st_brevin = time_st_brevin;
 	}
+	
+  public String getClosed_to() {
+    return closed_to;
+  }
+
+  public void setClosed_to(String closed_to) {
+    this.closed_to = closed_to;
+  }
+  
+  public String getClosed_from() {
+    return closed_from;
+  }
+
+  public void setClosed_from(String closed_from) {
+    this.closed_from = closed_from;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }  
 
 }

--- a/WEB-INF/plugins/InforoutesPlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/InforoutesPlugin/properties/languages/fr.prop
@@ -362,6 +362,9 @@ jcmsplugin.inforoutes.stnazaire: Saint-Nazaire
 jcmsplugin.inforoutes.stbrevin: Saint-Brevin
 jcmsplugin.inforoutes.morethantime: + de {0}
 jcmsplugin.inforoutes.minimum.trafic.dense: Temps en minutes min. pour considérer un trafic dense
+jcmsplugin.inforoutes.fermeture-date: Fermeture le {0} de {1} à {2}
+jcmsplugin.inforoutes.fermeture-periode: Fermeture du {0} - {1} au {2} - {3}
+
 
 # Labels Info trafic
 jcmsplugin.inforoutes.evenement.nature.legende.lbl:             Légende

--- a/plugins/InforoutesPlugin/jsp/psn/fermeture.jsp
+++ b/plugins/InforoutesPlugin/jsp/psn/fermeture.jsp
@@ -17,18 +17,16 @@ PSNSens itFermeture = PontHtmlHelper.getProchaineFermeture();
 				        <span class="ds44-iconInnerText">
                             <jalios:select>
                                 <%
-                                String dateDebut = SocleUtils.formatDate("dd/MM/yyyy", itFermeture.getDateDeDebut());
-                                String dateFin = SocleUtils.formatDate("dd/MM/yyyy", itFermeture.getEdate());
-                                String heureDebut = SocleUtils.formatDate("HH:mm", itFermeture.getDateDeDebut());
-                                String heureFin = SocleUtils.formatDate("HH:mm", itFermeture.getEdate());
+                                SimpleDateFormat sdfShownDate = new SimpleDateFormat(channel.getProperty("jcmsplugin.inforoutes.pattern.showndate"));
+                                SimpleDateFormat sdfShownHour = new SimpleDateFormat(channel.getProperty("jcmsplugin.inforoutes.pattern.shownhour"));
 			                     %>
 			                     
 			                    <jalios:if predicate='<%= PontHtmlHelper.isOuvertureEtFermetureLeMemeJour(itFermeture) %>'>
-                                    <%= glp("jcmsplugin.inforoutes.fermeture-date", dateDebut, heureDebut, heureFin) %>
+                                    <%= glp("jcmsplugin.inforoutes.fermeture-date", sdfShownDate.format(itFermeture.getDateDeDebut()), sdfShownHour.format(itFermeture.getDateDeDebut()), sdfShownHour.format(itFermeture.getEdate())) %>
 			                    </jalios:if>
 			                    
 			                    <jalios:default>
-                                    <%= glp("jcmsplugin.inforoutes.fermeture-periode", dateDebut, heureDebut, dateFin, heureFin) %>
+                                    <%= glp("jcmsplugin.inforoutes.fermeture-periode", sdfShownDate.format(itFermeture.getDateDeDebut()), sdfShownHour.format(itFermeture.getDateDeDebut()), sdfShownDate.format(itFermeture.getEdate()), sdfShownHour.format(itFermeture.getEdate())) %>
 			                    </jalios:default>
 			                    
 			                </jalios:select>

--- a/plugins/InforoutesPlugin/jsp/psn/fermeture.jsp
+++ b/plugins/InforoutesPlugin/jsp/psn/fermeture.jsp
@@ -1,0 +1,45 @@
+<%@page import="fr.cg44.plugin.socle.SocleUtils"%>
+<%@ page import="fr.cg44.plugin.inforoutes.legacy.pont.PontHtmlHelper"%>
+<%@ include file='/jcore/doInitPage.jsp' %>
+<%@ page contentType="text/html; charset=UTF-8" %>
+
+<%
+PSNSens itFermeture = PontHtmlHelper.getProchaineFermeture();
+%>
+
+<jalios:if predicate='<%= Util.notEmpty(itFermeture) && itFermeture.getDateDeDebut() != null && itFermeture.getEdate() != null %>'>
+    <div class="ds44-inner-container ds44-mtb5">
+        <div class="grid-12-small-1">
+            <div class="col-12">
+            
+				<div id="error-mgs9" class="ds44-msg-container error txtcenter" tabindex="-1" data-old-tabindex="-1">
+				    <p class="ds44-message-text"><i class="icon icon-attention icon--sizeM" aria-hidden="true"></i>
+				        <span class="ds44-iconInnerText">
+                            <jalios:select>
+                                <%
+                                String dateDebut = SocleUtils.formatDate("dd/MM/yyyy", itFermeture.getDateDeDebut());
+                                String dateFin = SocleUtils.formatDate("dd/MM/yyyy", itFermeture.getEdate());
+                                String heureDebut = SocleUtils.formatDate("HH:mm", itFermeture.getDateDeDebut());
+                                String heureFin = SocleUtils.formatDate("HH:mm", itFermeture.getEdate());
+			                     %>
+			                     
+			                    <jalios:if predicate='<%= PontHtmlHelper.isOuvertureEtFermetureLeMemeJour(itFermeture) %>'>
+                                    <%= glp("jcmsplugin.inforoutes.fermeture-date", dateDebut, heureDebut, heureFin) %>
+			                    </jalios:if>
+			                    
+			                    <jalios:default>
+                                    <%= glp("jcmsplugin.inforoutes.fermeture-periode", dateDebut, heureDebut, dateFin, heureFin) %>
+			                    </jalios:default>
+			                    
+			                </jalios:select>
+				        </span>
+				    </p>
+
+				</div>         
+
+
+              
+            </div>
+        </div>
+    </div>
+</jalios:if>

--- a/plugins/InforoutesPlugin/jsp/psn/psn.jspf
+++ b/plugins/InforoutesPlugin/jsp/psn/psn.jspf
@@ -1,5 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8"%>
 
+<%= getPortlet(bufferMap,"fermeture") %>
+
 <div class="ds44-inner-container ds44-mtb3">
 	<div class="grid-12-small-1">
 		<div class="col-3"><%= getPortlet(bufferMap,"trafic") %></div>


### PR DESCRIPTION
En cas de fermeture, une portlet JSP vient s'intégrer dans la page et affiche les dates de fermeture.