### PR TITLE
Evol : pictos dans templates de newsletters

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/InforoutesUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/InforoutesUtils.java
@@ -11,6 +11,7 @@ import org.apache.log4j.Logger;
 import com.jalios.jcms.Channel;
 
 import fr.cg44.plugin.inforoutes.dto.EvenementDTO;
+import generated.RouteEvenement;
 
 public final class InforoutesUtils {
 	private static Channel channel = Channel.getChannel();
@@ -35,6 +36,19 @@ public final class InforoutesUtils {
 	    return itEvent.getNature();
 	}
 	
+  /**
+   * Renvoie la nature d'un événement, ou son type si sa nature est "Bacs de Loire" pour sélectionner plus tard
+   * une icône depuis un autre pool
+   * @param itEvent
+   * @return
+   */
+  public static String getNatureOrTypeEvent(RouteEvenement itEvent) {
+      if (itEvent.getNature().equals(channel.getProperty("jcmsplugin.inforoutes.evenement.nature.bacs"))) {
+          return itEvent.getTypeEvenement();
+      }
+      return itEvent.getNature();
+  }	
+	
 	/**
    * Retourne la classe CSS correspondant à la nature de l'évènement
    * 
@@ -51,7 +65,7 @@ public final class InforoutesUtils {
   /**
    * Retourne le picto correspondant à la nature de l'évènement
    * 
-   * @param nature nature de l'évènement
+   * @param itEvent l'évènement
    * @return L'URL du picto correspondant
    */
   public static String getPictoNatureEvt(EvenementDTO itEvent) {
@@ -61,6 +75,18 @@ public final class InforoutesUtils {
     LOGGER.debug("getPictoNatureEvt - Nature = " + nature + " / src picto = " + rootPng + srcPicto);
     return rootPng + srcPicto;
   }
+  
+  /**
+   * Retourne le picto correspondant à la nature de l'évènement
+   * 
+   * @param itEvent l'évènement
+   * @return L'URL du picto correspondant
+   */
+  public static String getPictoNatureEvt(RouteEvenement itEvent) {
+    String nature = getNatureOrTypeEvent(itEvent);
+    String srcPicto = getNatureValue("png", getNatureParam(nature));
+    return srcPicto;
+  }  
   
   /**
    * Renvoie le suffixe du nom de la prop associée à une nature

--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/AlertBean.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/AlertBean.java
@@ -2,6 +2,7 @@ package fr.cg44.plugin.inforoutes.newsletter;
 
 import com.jalios.jcms.WikiRenderer;
 import com.jalios.jcms.mail.MailManager;
+import com.jalios.jcms.wysiwyg.WysiwygRenderer;
 
 import generated.AlertCG;
 
@@ -13,8 +14,7 @@ public class AlertBean {
 	
 	public AlertBean(AlertCG alert){
 		this.titre = alert.getTitle();
-		this.chapo =  MailManager.replaceRelativeUrlsWithAbsoluteUrls(WikiRenderer.wiki2html(alert.getAbstract(), null, null));
-		//this.description =  MailManager.replaceRelativeUrlsWithAbsoluteUrls(WikiRenderer.wiki2html(alert.getDescription(), null, null));
+		this.chapo =  MailManager.replaceRelativeUrlsWithAbsoluteUrls(alert.getAbstract());
 		this.description =  "";
 	}
 	

--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/EventBean.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/EventBean.java
@@ -5,17 +5,18 @@ import java.lang.reflect.Method;
 
 import org.apache.log4j.Logger;
 
+import com.jalios.jcms.Channel;
 import com.jalios.util.Util;
 
+import fr.cg44.plugin.inforoutes.InforoutesUtils;
 import fr.cg44.plugin.inforoutes.legacy.infotraficplugin.InfoTraficTempsReelContentFactory;
-import fr.cg44.plugin.inforoutes.newsletter.NewsletterManager;
 import generated.RouteEvenement;
 
 public class EventBean {
 	
 	private static final Logger logger = Logger.getLogger(EventBean.class);
 	
-	private static final String pictoURL ="https://inforoutes.loire-atlantique.fr/plugins/InforoutesPlugin/images/infoRoutes/";
+	private static final String pictoURL = Channel.getChannel().getProperty("jcmsplugin.inforoutes.designsystem.png.folder");
 	
 	private String nature;	
 	private String ligne1;
@@ -54,7 +55,7 @@ public class EventBean {
 	 * @return
 	 */
 	private static String buildNature(RouteEvenement event) {
-		String nature = pictoURL + "picto_" + InfoTraficTempsReelContentFactory.getClassNature(event.getNature()) + ".png";
+		String nature = InforoutesUtils.getPictoNatureEvt(event);
 		return nature;
 	}
 	

--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/PsnSensBean.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/PsnSensBean.java
@@ -11,7 +11,7 @@ import generated.PSNSens;
 
 public class PsnSensBean {
 	
-	private SimpleDateFormat dateFormat = new SimpleDateFormat("dd|MM|yyyy");
+	private SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
 	private SimpleDateFormat heureFormat = new SimpleDateFormat("HH:mm");
 	private Channel channel = Channel.getChannel();
 	
@@ -28,7 +28,6 @@ public class PsnSensBean {
 			this.mentionHTMLHaut =  Util.notEmpty(picto.getMentionHTMLHaut()) ? picto.getMentionHTMLHaut() : "";
 			this.mentionHTMLBas =  Util.notEmpty(picto.getMentionHTMLHaut()) ? picto.getMentionHTMLBas() : "";
 			this.texteAlternatif = picto.getTexteAlternatif();
-			//this.picto = "https://inforoutes.loire-atlantique.fr/" + picto.getPictogramme();
 			this.picto = channel.getProperty("jcmsplugin.inforoutes.designsystem.png.folder") + picto.getTitle().toLowerCase() + ".png";
 		
 			if(Util.notEmpty(sens.getDateDeDebut() ) && now.after(sens.getDateDeDebut())){

--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/PsnSensBean.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/newsletter/PsnSensBean.java
@@ -3,6 +3,7 @@ package fr.cg44.plugin.inforoutes.newsletter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import com.jalios.jcms.Channel;
 import com.jalios.util.Util;
 
 import generated.CG44PontPictogramme;
@@ -12,6 +13,7 @@ public class PsnSensBean {
 	
 	private SimpleDateFormat dateFormat = new SimpleDateFormat("dd|MM|yyyy");
 	private SimpleDateFormat heureFormat = new SimpleDateFormat("HH:mm");
+	private Channel channel = Channel.getChannel();
 	
 	private String texteAlternatif;
 	private String picto;
@@ -26,7 +28,8 @@ public class PsnSensBean {
 			this.mentionHTMLHaut =  Util.notEmpty(picto.getMentionHTMLHaut()) ? picto.getMentionHTMLHaut() : "";
 			this.mentionHTMLBas =  Util.notEmpty(picto.getMentionHTMLHaut()) ? picto.getMentionHTMLBas() : "";
 			this.texteAlternatif = picto.getTexteAlternatif();
-			this.picto = "https://inforoutes.loire-atlantique.fr/" + picto.getPictogramme();
+			//this.picto = "https://inforoutes.loire-atlantique.fr/" + picto.getPictogramme();
+			this.picto = channel.getProperty("jcmsplugin.inforoutes.designsystem.png.folder") + picto.getTitle().toLowerCase() + ".png";
 		
 			if(Util.notEmpty(sens.getDateDeDebut() ) && now.after(sens.getDateDeDebut())){
 				date = "changement imminent";


### PR DESCRIPTION
Pointe vers le DS et plus dans le site Inforoutes.
Ajoute des méthode de récupération de picto pour les RouteEvenement en + des DTO.