### PR TITLE
Refact : mode indeterminé/particulier PSN

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/legacy/pont/service/impl/JcmsSyncService.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/legacy/pont/service/impl/JcmsSyncService.java
@@ -63,7 +63,7 @@ public class JcmsSyncService implements IJcmsSyncService {
    */
   private static HashMap<String, String> pictoIdCache = new HashMap<String, String>();
 
-  private long nbMillisModeParticulier = 30 * 60000l;
+  private long nbMillisModeParticulier = 10 * 60000l;
 
   /*
    * cache des id de PSNSens

--- a/plugins/InforoutesPlugin/jsp/legacy/api/psnstatus.jsp
+++ b/plugins/InforoutesPlugin/jsp/legacy/api/psnstatus.jsp
@@ -5,7 +5,6 @@
 %><%@	page import="fr.cg44.plugin.inforoutes.legacy.pont.PontHtmlHelper"			%><%
 %><%
 	String json = Psnstatus.generateStatus();
-	json = json.replaceAll("MODE_PARTICULIER", "INDETERMINE" );
 	response.setContentType("application/json");
 	out.print(json);
 %>


### PR DESCRIPTION
Abaissement de 30 à 10 mn avant de passer du mode indéterminé au mode particulier.
Suppression du fix JCMS8 qui forçait le mode indeterminé dans l'API.