### PR TITLE
Fix : gestion erreur de flux json sur PSN

### DIFF
--- a/plugins/InforoutesPlugin/jsp/includes/displayTraffic.jspf
+++ b/plugins/InforoutesPlugin/jsp/includes/displayTraffic.jspf
@@ -45,8 +45,6 @@ lblTimeBToA = Integer.parseInt(psnStatut.getTime_st_brevin()) >= 20 ? glp("jcmsp
 
 %>
 
-<h2 class="h2-like h2-like--mobileSize"><%= glp("jcmsplugin.inforoutes.trafic") %></h2>
-
 <section class="ds44-mtb3">
    <h3 class="h5-like ds44-mb1" role="heading"><%= lblCityA %><span aria-hidden="true"> &gt; <span class="visually-hidden"><%= glp("jcmsplugin.inforoutes.vers") %></span></span><%= lblCityB %></h3>
    <section class="ds44-card ds44-card--horizontal--inforoutes">

--- a/plugins/InforoutesPlugin/jsp/trafficStNazaire.jsp
+++ b/plugins/InforoutesPlugin/jsp/trafficStNazaire.jsp
@@ -12,8 +12,10 @@ TraficParametersDTO traficParams = InforoutesApiRequestManager.getTraficParamete
 String lblCityA = glp("jcmsplugin.inforoutes.stnazaire");
 String lblCityB = glp("jcmsplugin.inforoutes.stbrevin");
 %>
+<h2 class="h2-like h2-like--mobileSize"><%= glp("jcmsplugin.inforoutes.trafic") %></h2>
+
 <jalios:select>
-    <jalios:if predicate="<%= Util.isEmpty(traficParams) %>">
+    <jalios:if predicate="<%= Util.isEmpty(traficParams) || Util.notEmpty(psnStatut.getError()) %>">
         <p><%= glp("jcmsplugin.inforoutes.erreur.trafic") %></p>
     </jalios:if>
     <jalios:default>


### PR DESCRIPTION
Fix car si le flux json contient une erreur (dans l'attribut "error" de psnstatus), alors le jspf lève une exception.