### PR TITLE
Fix fermeture PSN

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/inforoutes/legacy/pont/PontHtmlHelper.java
+++ b/WEB-INF/classes/fr/cg44/plugin/inforoutes/legacy/pont/PontHtmlHelper.java
@@ -195,4 +195,18 @@ public class PontHtmlHelper {
     return result;
   }
 
+  /**
+   * Teste si le pont est actuellement fermé
+   * (conditionne l'affichage de certains éléments sur le portail)
+   * 
+   * @return true si le pont est fermé (PSNSens de type "fermeture")
+   */
+  public static boolean isPontFerme() {
+    PSNSens sensCourant = getModeCirculationCourant();
+    if(null != sensCourant && Util.notEmpty(sensCourant.getSensDeCirculation()) && sensCourant.getSensDeCirculation().getTitle().equalsIgnoreCase("M000")) {
+        return true;
+    }
+    return false;
+
+  }  
 }

--- a/plugins/InforoutesPlugin/jsp/psn/fermeture.jsp
+++ b/plugins/InforoutesPlugin/jsp/psn/fermeture.jsp
@@ -5,13 +5,9 @@
 
 <%
 PSNSens itFermeture = PontHtmlHelper.getProchaineFermeture();
-boolean pontFerme = false; 
 %>
 
 <jalios:if predicate='<%= Util.notEmpty(itFermeture) && itFermeture.getDateDeDebut() != null && itFermeture.getEdate() != null %>'>
-    <%
-    pontFerme = true;
-    %>
     <div class="ds44-inner-container ds44-mtb5">
         <div class="grid-12-small-1">
             <div class="col-12">
@@ -45,5 +41,3 @@ boolean pontFerme = false;
         </div>
     </div>
 </jalios:if>
-
-<% request.setAttribute("pontFerme", pontFerme); %>

--- a/plugins/InforoutesPlugin/jsp/psn/psn.jsp
+++ b/plugins/InforoutesPlugin/jsp/psn/psn.jsp
@@ -11,7 +11,6 @@ ServletUtil.backupAttribute(pageContext , "ShowChildPortalElement");
 ServletUtil.restoreAttribute(pageContext , "ShowChildPortalElement");
 
 boolean isPontFerme = PontHtmlHelper.isPontFerme();
-request.setAttribute("isPontFerme", isPontFerme);
 %>
 
 <%@ include file='psn.jspf' %>

--- a/plugins/InforoutesPlugin/jsp/psn/psn.jsp
+++ b/plugins/InforoutesPlugin/jsp/psn/psn.jsp
@@ -1,12 +1,17 @@
 <%@ page contentType="text/html; charset=UTF-8"%>
 <%@ include file='/jcore/doInitPage.jspf' %>
-<%@ include file='/jcore/portal/doPortletParams.jspf' %><% 
+<%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ page import="fr.cg44.plugin.inforoutes.legacy.pont.PontHtmlHelper"%>
+<%
 PortletJspCollection box = (PortletJspCollection) portlet; 
 ServletUtil.backupAttribute(pageContext , "ShowChildPortalElement");
 %>
 <%@ include file='/types/AbstractCollection/doIncludePortletCollection.jspf'%>
 <%
 ServletUtil.restoreAttribute(pageContext , "ShowChildPortalElement");
+
+boolean isPontFerme = PontHtmlHelper.isPontFerme();
+request.setAttribute("isPontFerme", isPontFerme);
 %>
 
 <%@ include file='psn.jspf' %>

--- a/plugins/InforoutesPlugin/jsp/psn/psn.jspf
+++ b/plugins/InforoutesPlugin/jsp/psn/psn.jspf
@@ -2,17 +2,15 @@
 
 <%= getPortlet(bufferMap,"fermeture") %>
 
-<%
-// En cas de pont fermé on affiche juste la portlet qui indique le sens de circulation
-boolean pontFerme = (boolean)request.getAttribute("pontFerme");
-%>
+<%-- En cas de pont fermé on affiche juste la portlet qui indique le sens de circulation --%>
+
 <div class="ds44-inner-container ds44-mtb3">
 	<div class="grid-12-small-1">
-		<div class="col-3"><jalios:if predicate='<%= ! pontFerme %>'><%= getPortlet(bufferMap,"trafic") %></jalios:if></div>
+		<div class="col-3"><jalios:if predicate='<%= ! isPontFerme %>'><%= getPortlet(bufferMap,"trafic") %></jalios:if></div>
         <div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
         <div class="col-3"><%= getPortlet(bufferMap,"sensCirculation") %></div>
         <div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
-        <div class="col-4"><jalios:if predicate='<%= ! pontFerme %>'><%= getPortlet(bufferMap,"webcam") %></jalios:if></div>
+        <div class="col-4"><jalios:if predicate='<%= ! isPontFerme %>'><%= getPortlet(bufferMap,"webcam") %></jalios:if></div>
 	</div>
 </div>
 


### PR DESCRIPTION
Masquer les portlets "trafic" et "webcam" uniquement quand le point est actuellement fermé, et pas quand il y a une fermeture prochaine.
Rajout d'une méthode de détection de fermeture actuelle.